### PR TITLE
Set WiFi into station mode

### DIFF
--- a/src/nRF905API/nRF905API.ino
+++ b/src/nRF905API/nRF905API.ino
@@ -48,6 +48,7 @@ void setup() {
 	Serial.println(firmware_version);
 
 	// Connect to WiFi network
+	WiFi.mode(WIFI_STA);
 	WiFi.begin(_ssid, _password);
 	board->set_hostname(_hostname);
 


### PR DESCRIPTION
This change sets wifi into station mode. I noticed that the NodeMCU was starting a open wifi network (SSID: FaryLink_XXX). This stops the NodeMCU starting its own AP.