### PR TITLE
Fix strncpy sizeof + missing WiFi include for ESP32

### DIFF
--- a/src/nRF905API/fan.h
+++ b/src/nRF905API/fan.h
@@ -24,6 +24,7 @@ enum {	FAN_FRAME_SETVOLTAGE			= 0x01,		// Set speed (voltage / percentage)
 	FAN_NETWORK_JOIN_OPEN			= 0x06,
 	FAN_TYPE_FAN_SETTINGS			= 0x07,		// Current settings, sent by fan in reply to 0x01, 0x02, 0x10
 	FAN_FRAME_0B				= 0x0B,
+	FAN_FRAME_04				= 0x04,
 	FAN_NETWORK_JOIN_ACK			= 0x0C,
 //	FAN_NETWORK_JOIN_FINISH		= 0x0D,
 	FAN_TYPE_QUERY_NETWORK			= 0x0D,

--- a/src/nRF905API/nRF905API.h
+++ b/src/nRF905API/nRF905API.h
@@ -6,6 +6,8 @@
 #ifndef __NRF905API_H__
 #define __NRF905API_H__
 
+#include "config.h"
+
 #if NRF905API_HTTPS == 1
 #include "certificate.h"
 #endif

--- a/src/nRF905API/nRF905API.ino
+++ b/src/nRF905API/nRF905API.ino
@@ -118,8 +118,8 @@ void setup() {
 		if (checkNVRAMIsValidData() == false) {
 			loadNVRAMDefaults();
 		}
-		strncpy(config.http_username, "", sizeof(MAX_HTTP_USERNAME));
-		strncpy(config.http_password, "", sizeof(MAX_HTTP_PASSWORD));
+		strncpy(config.http_username, "", MAX_HTTP_USERNAME);
+		strncpy(config.http_password, "", MAX_HTTP_PASSWORD);
 
 		server.begin();
 		htmlAddHandlers();
@@ -235,9 +235,9 @@ void setup() {
 	rxnum = 0;
 	rx_buffer_overflow = false;
 	Serial.printf("nRF905: switching to receive mode\n");
-	Serial.printf("mode=%i", nrf905->getMode());
+	Serial.printf("mode=%i\n", nrf905->getMode());
 	nrf905->setModeReceive();
-	Serial.printf("mode=%i", nrf905->getMode());
+	Serial.printf("mode=%i\n", nrf905->getMode());
 	Serial.printf("Setup done\n");
 }
 

--- a/src/nRF905API/nRF905API.ino
+++ b/src/nRF905API/nRF905API.ino
@@ -193,6 +193,9 @@ void setup() {
 	// Set the certificates from PMEM (if using DRAM remove the _P from the call)
 	server.getServer().setRSACert(new BearSSL::X509List(serverCert), new BearSSL::PrivateKey(serverKey));
 //	server.getServer().setServerKeyAndCert_P(rsakey, sizeof(rsakey), x509, sizeof(x509));
+#ifdef ARDUINO_ARCH_ESP8266
+	server.getServer().setBufferSizes(2048, 837);
+#endif
 #endif
 
 	// Start the HTTP server

--- a/src/nRF905API/src/api/json_api_v1.cpp
+++ b/src/nRF905API/src/api/json_api_v1.cpp
@@ -309,9 +309,6 @@ void apiv1_status() {
 	server.sendContent(",\"system_status\":{");
 	server.sendContent("\"board\":\"" + board->get_arch() + "\",");
 	server.sendContent("\"firmware_version\":\"" + String(FPSTR(firmware_version)) + "\",");
-#if NRF905API_NTP == 1
-	server.sendContent("\"system_time\":\"" + timeClient.getFormattedTime() + "\",");
-#endif
 	server.sendContent("\"restart_reason\":" + String(board->restartReason()) + ",");
 	server.sendContent("\"cpu_id\":\"" + String(board->get_cpu_id(), HEX) + "\",");
 	server.sendContent("\"cpu_frequency\":" + String(board->getCPUFreqMhz()) + ",");

--- a/src/nRF905API/src/hardware/bcm2835.cpp
+++ b/src/nRF905API/src/hardware/bcm2835.cpp
@@ -1,9 +1,9 @@
 #ifdef RPI
 
 #include <SPI.h>
-#include "esp32.h"
 #include "../../board.h"	// board-> functions
 #include "../../utils.h"	// serialPrintHex()
+#include "esp32.h"
 
 // Create an instance of the server
 #if NRF905API_HTTPS == 1

--- a/src/nRF905API/src/hardware/esp32.cpp
+++ b/src/nRF905API/src/hardware/esp32.cpp
@@ -3,10 +3,10 @@
 #include <EEPROM.h>
 #include <SPI.h>
 #include <rom/rtc.h>		// RESET_REASON
-#include "esp32.h"
 #include "../../board.h"	// board-> functions
 #include "../../nvram.h"	// NVRAMBuffer
 #include "../../utils.h"	// serialPrintHex()
+#include "esp32.h"
 
 // Create an instance of the server
 #if NRF905API_HTTPS == 1

--- a/src/nRF905API/src/hardware/esp32.cpp
+++ b/src/nRF905API/src/hardware/esp32.cpp
@@ -208,11 +208,11 @@ void Board::set_hostname(const char *hostname) {
 }
 
 String Board::get_localIPv6(void) {
-	return WiFi.localIPv6().toString();
+	return WiFi.localIP().toString();
 }
 
 bool Board::enable_IPv6(void) {
-	return WiFi.enableIpV6();
+	return WiFi.enableIPv6();
 }
 
 void Board::setPinMode(const uint8_t pin, const uint8_t mode) {

--- a/src/nRF905API/src/hardware/esp32.h
+++ b/src/nRF905API/src/hardware/esp32.h
@@ -5,6 +5,7 @@
 
 #include <SPI.h>	// SPIClass
 
+#include <WiFi.h>
 #if NRF905API_HTTPS == 1
 #include <WebServerSecure.h>
 extern WebServerSecure server;

--- a/src/nRF905API/src/hardware/esp8266.cpp
+++ b/src/nRF905API/src/hardware/esp8266.cpp
@@ -2,10 +2,10 @@
 
 #include <EEPROM.h>
 #include <SPI.h>
-#include "esp8266.h"
 #include "../../board.h"	// board-> functions
 #include "../../nvram.h"	// NVRAMBuffer
 #include "../../utils.h"	// serialPrintHex()
+#include "esp8266.h"
 
 // Create an instance of the server
 #if NRF905API_HTTPS == 1

--- a/src/nRF905API/src/html/configwizard.cpp
+++ b/src/nRF905API/src/html/configwizard.cpp
@@ -35,7 +35,7 @@ void htmlConfigWizardLanguage(void) {
 
 	if (server.method() == HTTP_POST) {
 		if (server.hasArg("language")) {
-			strncpy(config.language, server.arg("language").c_str(), sizeof(MAX_LANGUAGE));
+			strncpy(config.language, server.arg("language").c_str(), MAX_LANGUAGE);
 		}
 	}
 
@@ -78,10 +78,10 @@ void htmlConfigWizardAuthentication(void) {
 
 	if (server.method() == HTTP_POST) {
 		if (server.hasArg("http_username")) {
-			strncpy(config.http_username, server.arg("http_username").c_str(), sizeof(MAX_HTTP_USERNAME));
+			strncpy(config.http_username, server.arg("http_username").c_str(), MAX_HTTP_USERNAME);
 		}
 		if (server.hasArg("http_password")) {
-			strncpy(config.http_password, server.arg("http_password").c_str(), sizeof(MAX_HTTP_PASSWORD));
+			strncpy(config.http_password, server.arg("http_password").c_str(), MAX_HTTP_PASSWORD);
 		}
 	}
 
@@ -121,7 +121,7 @@ void htmlConfigWizardWifi(void) {
 
 	if (server.method() == HTTP_POST) {
 		if (server.hasArg("hostname")) {
-			strncpy(config.wifi_hostname, server.arg("hostname").c_str(), sizeof(MAX_WIFI_HOSTNAME));
+			strncpy(config.wifi_hostname, server.arg("hostname").c_str(), sizeof(config.wifi_hostname));
 		}
 		if (server.hasArg("ssid")) {
 			strncpy(config.wifi_ssid, server.arg("ssid").c_str(), sizeof(config.wifi_ssid));
@@ -421,9 +421,9 @@ void htmlConfigWizardAdvanced(void) {
 	if (server.method() == HTTP_POST) {
 		/* TODO input validation */
 		if (server.hasArg("ntpserver"))
-			strncpy(config.ntp_server, server.arg("ntpserver").c_str(), sizeof(MAX_NTPSERVER));
+			strncpy(config.ntp_server, server.arg("ntpserver").c_str(), MAX_NTPSERVER);
 		else
-			strncpy(config.ntp_server, DEFAULT_NTP_SERVER, sizeof(MAX_NTPSERVER));
+			strncpy(config.ntp_server, DEFAULT_NTP_SERVER, MAX_NTPSERVER);
 		if (server.hasArg("ntpoffset"))
 			config.ntp_offset = server.arg("ntpoffset").toInt();
 		else
@@ -433,9 +433,9 @@ void htmlConfigWizardAdvanced(void) {
 		else
 			config.ntp_interval = DEFAULT_NTP_INTERVAL;
 		if (server.hasArg("ota_password"))
-			strncpy(config.ota_password, server.arg("ota_password").c_str(), sizeof(MAX_OTA_PASSWORD));
+			strncpy(config.ota_password, server.arg("ota_password").c_str(), MAX_OTA_PASSWORD);
 		else
-			strncpy(config.ota_password, DEFAULT_OTA_PASSWORD, sizeof(MAX_OTA_PASSWORD));
+			strncpy(config.ota_password, DEFAULT_OTA_PASSWORD, MAX_OTA_PASSWORD);
 		if (server.hasArg("ota_port"))
 			config.ota_port = server.arg("ota_port").toInt();
 		else

--- a/src/nRF905API/src/html/html.cpp
+++ b/src/nRF905API/src/html/html.cpp
@@ -45,13 +45,13 @@ void htmlConfig() {
 		/* TODO input validation */
 		config.signature = NVRAM_SIGNATURE;
 		config.version = NVRAM_VERSION;
-		strncpy(config.wifi_hostname, server.arg("hostname").c_str(), sizeof(MAX_WIFI_HOSTNAME));
+		strncpy(config.wifi_hostname, server.arg("hostname").c_str(), MAX_WIFI_HOSTNAME);
 		strncpy(config.wifi_ssid, server.arg("ssid").c_str(), sizeof(config.wifi_ssid));
 		strncpy(config.wifi_password, server.arg("wifi_password").c_str(), sizeof(config.wifi_password));
 		if (server.hasArg("ntpserver"))
-			strncpy(config.ntp_server, server.arg("ntpserver").c_str(), sizeof(MAX_NTPSERVER));
+			strncpy(config.ntp_server, server.arg("ntpserver").c_str(), MAX_NTPSERVER);
 		else
-			strncpy(config.ntp_server, DEFAULT_NTP_SERVER, sizeof(MAX_NTPSERVER));
+			strncpy(config.ntp_server, DEFAULT_NTP_SERVER, MAX_NTPSERVER);
 		if (server.hasArg("ntpoffset"))
 			config.ntp_offset = server.arg("ntpoffset").toInt();
 		else
@@ -61,15 +61,15 @@ void htmlConfig() {
 		else
 			config.ntp_interval = DEFAULT_NTP_INTERVAL;
 		if (server.hasArg("ota_password"))
-			strncpy(config.ota_password, server.arg("ota_password").c_str(), sizeof(MAX_OTA_PASSWORD));
+			strncpy(config.ota_password, server.arg("ota_password").c_str(), MAX_OTA_PASSWORD);
 		else
-			strncpy(config.ota_password, DEFAULT_OTA_PASSWORD, sizeof(MAX_OTA_PASSWORD));
+			strncpy(config.ota_password, DEFAULT_OTA_PASSWORD, MAX_OTA_PASSWORD);
 		if (server.hasArg("ota_port"))
 			config.ota_port = server.arg("ota_port").toInt();
 		else
 			config.ota_port = DEFAULT_OTA_PORT;
-		strncpy(config.http_username, server.arg("http_username").c_str(), sizeof(MAX_HTTP_USERNAME));
-		strncpy(config.http_password, server.arg("http_password").c_str(), sizeof(MAX_HTTP_PASSWORD));
+		strncpy(config.http_username, server.arg("http_username").c_str(), MAX_HTTP_USERNAME);
+		strncpy(config.http_password, server.arg("http_password").c_str(), MAX_HTTP_PASSWORD);
 
 		switch (server.arg("profile").toInt()) {
 			case FAN_PROFILE_ZEHNDER :	// Zehnder


### PR DESCRIPTION
Hello,
Thank you very much for this awesome project!
During deployment, I noticed that changing the password did not worked.
It was simply a little bug, using `sizeof(SIZE)` instead of `SIZE` directly in most `strncpy` calls.
Just fixed it in this PR.
I also fixed the missing declaration of `FAN_FRAME_04` and some cosmetic in prints.